### PR TITLE
Fix dark mode: background-color-darken-2 missing

### DIFF
--- a/themes/Clean/css/dark.css
+++ b/themes/Clean/css/dark.css
@@ -621,6 +621,7 @@ body .closed-task-list-view li:hover {
     --background-color-page-lighten-3: #080808;
     --background-color-page-lighten-30: #4d4d4d;
     --background-color-secondary-darken-5: #262626;
+    --background-color-secondary-darken-2: #2e2e2e;
     --default-darken-5: #000000;
     --text-color-secondary-lighten-25: #fbfbfb;
 


### PR DESCRIPTION
A user reported to me that a file attachment in a comment showed with light background color and light text color.
(Only in the dark mode of clean theme.)

So this is the most simple fix I guess.
I think there are no less files for the dark mode anymore, right?
(It's ok as with Bootstrap 5 it will all change anyways.)